### PR TITLE
Fix typos and grammar in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Koukan: Cloud-Native Email Transport
 
-Koukan is an Cloud-Native email transport stack.
+Koukan is a Cloud-Native email transport stack.
 
 [Documentation](https://koukan-mta.net/)
 

--- a/koukan/async_filter_wrapper.py
+++ b/koukan/async_filter_wrapper.py
@@ -13,7 +13,7 @@ from koukan.storage_schema import VersionConflictException
 from koukan.response import Response
 from koukan.backoff import backoff
 
-# AsyncFilterWrapper provdes store&forward business logic on top of
+# AsyncFilterWrapper provides store&forward business logic on top of
 # StorageWriterFilter for Exploder and related workflows
 # (AddRouteFilter). This consists of ~4 things:
 # 1: version conflict retries

--- a/koukan/docs/api.rst
+++ b/koukan/docs/api.rst
@@ -208,7 +208,7 @@ Koukan will return a URL to PUT the blob to::
     POST /senders/submission/transactions HTTP/1.1
     Content-type: application/json
     {"mail_from": {"m": "alice@example.com"},
-     "rcpt_to": {"m": "bob@example.com"}}}}
+     "rcpt_to": {"m": "bob@example.com"}}
 
     201 created
     Location: /transactions/xyz
@@ -289,7 +289,7 @@ upload the rfc822 message::
 additionally, if you enable message parsing in the output chain::
 
     PUT /transactions/<tx id>/message_builder HTTP/1.1
-    PUT /transactions<tx id>/blob/<blob id> HTTP/1.1
+    PUT /transactions/<tx id>/blob/<blob id> HTTP/1.1
 
 for each blob in the message builder spec json
 

--- a/koukan/docs/config.rst
+++ b/koukan/docs/config.rst
@@ -484,7 +484,7 @@ authentication. Replaces ``relay_auth`` filter
 num_rcpts: matches if the number of rcpts prior to this rcpt with a
 success response is >= yaml max_rcpts
 
-invalid_mail_from: matches if the mail_from mailbox is in invalid
+invalid_mail_from: matches if the mail_from mailbox is invalid
 
 invalid_rcpt_to: PER_RCPT matcher that matches if the rcpt_to mailbox is invalid
 

--- a/koukan/docs/faq.rst
+++ b/koukan/docs/faq.rst
@@ -34,7 +34,7 @@ Yes
 
 - You have an application that sends/receives email and don't like your current
   solution such that you're interested in porting it to a new email api.
-- You have have experience running an MTA on the public internet.
+- You have experience running an MTA on the public internet.
 - You have some experience with http/rest apis.
 - You're willing to get your hands dirty with Python.
 

--- a/koukan/docs/overview.rst
+++ b/koukan/docs/overview.rst
@@ -2,7 +2,7 @@
 Overview
 ========
 
-Koukan is an Cloud-Native email transport stack. Koukan provides a
+Koukan is a Cloud-Native email transport stack. Koukan provides a
 rich http/json rest api for new-build applications to send and receive
 email. The rest api includes rfc822/MIME message formatting, DKIM
 signing, etc. The rest api also reports many errors immediately rather
@@ -140,7 +140,7 @@ Storage → OutputHandler → FilterChain → ...Exploder → Storage
 
 Storage → OutputHandler → ...
 
-where the Exploder fans out a separate upstream transaction for reach
+where the Exploder fans out a separate upstream transaction for each
 rcpt of the downstream transaction and fans the upstream responses
 back in.
 

--- a/koukan/docs/quickstart.rst
+++ b/koukan/docs/quickstart.rst
@@ -36,9 +36,9 @@ If you want the Koukan smtp gateway to terminate port 25/587 connections
 directly from the public internet, you will need to arrange for it to
 be able to bind privileged ports. On Linux, you can do this with ``capsh`` per this Stack Overflow `answer <https://stackoverflow.com/questions/413807/is-there-a-way-for-non-root-processes-to-bind-to-privileged-ports-on-linux>`__
 
-Alternatively, you use a front proxy such as `Envoy
+Alternatively, you can use a front proxy such as `Envoy
 <https://envoyproxy.io>`__ to terminate port 25 and let the gateway
-listen on an unprivilged port. Note that Envoy cannot currently
+listen on an unprivileged port. Note that Envoy cannot currently
 terminate SMTP STARTTLS but there has been some work in this area
 `bug`_.
 

--- a/koukan/message_parser.py
+++ b/koukan/message_parser.py
@@ -60,7 +60,7 @@ class MessageParser:
             'content-disposition': self._parse_parameter_header,
             'content-type': self._parse_parameter_header,
 
-            # TODO default HeaderRegistery doesn't map in-reply-to to
+            # TODO default HeaderRegistry doesn't map in-reply-to to
             # MessageIDHeader
             #'in-reply-to': self._parse_messageid_header,
 

--- a/koukan/output_handler.py
+++ b/koukan/output_handler.py
@@ -365,7 +365,7 @@ class OutputHandler:
         # append body/blob data will probably not fail even if the
         # upstream transaction
         # has permfailed since:
-        # - Exploder doesn't check for upstream errors after it it has
+        # - Exploder doesn't check for upstream errors after it has
         # decided to store&forward
         # - downstream StorageWriterFilter/RestHandler stack doesn't
         # have the logic to fail the PUT in that case

--- a/koukan/storage_test.py
+++ b/koukan/storage_test.py
@@ -689,7 +689,7 @@ class StorageTestBase(unittest.TestCase):
     # upstream/OutputHandler
     # one does a write
     # the other verifies it reads it back from the cache
-    # then a 3rd cursor reads it from the db and verfies it got the
+    # then a 3rd cursor reads it from the db and verifies it got the
     # same thing as the cache
     def test_handoff(self):
         prev_reads = self.s._tx_reads


### PR DESCRIPTION
Documentation/prose:
- overview: "an Cloud-Native" -> "a"; "for reach rcpt" -> "for each rcpt"
- quickstart: "you use a front proxy" -> "you can use"; "unprivilged" ->
  "unprivileged"
- faq: doubled word "have have" -> "have"
- config: "mailbox is in invalid" -> "is invalid"
- api: missing "/" in example path; fix unbalanced braces in JSON example
- README: "an Cloud-Native" -> "a Cloud-Native"

Code comments:
- async_filter_wrapper: "provdes" -> "provides"
- output_handler: doubled word "it it" -> "it"
- message_parser: "HeaderRegistery" -> "HeaderRegistry"
- storage_test: "verfies" -> "verifies"