### PR TITLE
Fix mypy errors in example sender scripts

### DIFF
--- a/examples/send_message/BUILD
+++ b/examples/send_message/BUILD
@@ -2,10 +2,12 @@ exports_files(['body.txt'])
 
 py_library(name='trivial_json_sender',
            srcs=['trivial_json_sender.py'],
+           deps=['@pypi//requests'],
            visibility=['//visibility:public'])
 
 py_library(name='trivial_rfc822_sender',
            srcs=['trivial_rfc822_sender.py'],
+           deps=['@pypi//requests'],
            visibility=['//visibility:public'])
 
 py_library(name='send_message',

--- a/examples/send_message/trivial_json_sender.py
+++ b/examples/send_message/trivial_json_sender.py
@@ -69,10 +69,10 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    message_builder = None
-    if args.message_builder_filename:
-      with open(args.message_builder_filename, 'r') as f:
-        message_builder = json.load(f)
+    if not args.message_builder_filename:
+      parser.error('--message_builder_filename is required')
+    with open(args.message_builder_filename, 'r') as f:
+      message_builder = json.load(f)
 
     logging.debug(message_builder)
 

--- a/examples/send_message/trivial_rfc822_sender.py
+++ b/examples/send_message/trivial_rfc822_sender.py
@@ -69,11 +69,11 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    rfc822_message = None
-    if args.rfc822_filename:
-        # open as text messes with line endings
-        with open(args.rfc822_filename, 'rb') as f:
-            rfc822_message = f.read().decode('utf-8')
+    if not args.rfc822_filename:
+        parser.error('--rfc822_filename is required')
+    # open as text messes with line endings
+    with open(args.rfc822_filename, 'rb') as f:
+        rfc822_message = f.read().decode('utf-8')
 
     logging.debug(args.rcpt_to)
 


### PR DESCRIPTION
trivial_json_sender and trivial_rfc822_sender import `requests` but, unlike the sibling send_message target, did not declare it as a Bazel dep, so mypy could not resolve its stubs. Add the missing `@pypi//requests` dep to both.

Also require --message_builder_filename / --rfc822_filename rather than defaulting the message to None and passing it into a function typed for str/dict: without the flag the script would otherwise build a transaction with a None body. Erroring out early fixes both the type error and that latent bug.